### PR TITLE
Added Boom Hammer and fixed playthrough-id for Laurence's Skull + typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,6 +390,7 @@
             <li data-id="playthrough_24_4">Pick up <a href="https://bloodborne.wiki.fextralife.com/Old+Hunter+Garb">Old Hunter Garb</a>.</li>
             <li data-id="playthrough_24_5">Defeat the <a href="https://bloodborne.wiki.fextralife.com/Hostile+Hunters">Beast Claw hunter</a> to receive <a href="https://bloodborne.wiki.fextralife.com/Firing+Hammer+Badge">Firing Hammer Badge</a>.</li>
             <li data-id="playthrough_24_6">Pick up <a href="https://bloodborne.wiki.fextralife.com/Old+Hunter+Top+Hat">Old Hunter Top Hat</a>.</li>
+            <li data-id="playthrough_24_21">Pick up <a href="https://bloodborne.wiki.fextralife.com/Boom+Hammer">Boom Hammer</a>.</li>
             <li data-id="playthrough_24_7">Defeat the <a href="https://bloodborne.wiki.fextralife.com/Hostile+Hunters">Gatling Gun hunter</a> to receive <a href="https://bloodborne.wiki.fextralife.com/Gatling+Gun">Gatling Gun</a>.</li>
             <li data-id="playthrough_24_8">Pick up <a href="https://bloodborne.wiki.fextralife.com/Amygdalan+Arm">Amygdalan Arm</a>.</li>
             <li data-id="playthrough_24_9">Talk to <a href="https://bloodborne.wiki.fextralife.com/Simon+the+Harrowed">Simon the Harrowed</a> and answer "Nightmares are fascinating" to start his questline.</li>
@@ -403,7 +404,7 @@
             <li data-id="playthrough_24_17">Talk to Ludwig's head while wearing any church garb and answer "Yes", or kill the head, to receive <a href="https://bloodborne.wiki.fextralife.com/Holy+Moonlight+Sword">Holy Moonlight Sword</a>.</li>
             <li data-id="playthrough_24_18">Pick up <a href="https://bloodborne.wiki.fextralife.com/First+Of+Gratia">Fist of Gratia</a>.</li>
             <li data-id="playthrough_24_19">Pick up <a href="https://bloodborne.wiki.fextralife.com/Blood+Stone+Chunk">Blood Stone Chunk</a>.</li>
-            <li data-id="playthrough_25_20">Pick up <a href="https://bloodborne.wiki.fextralife.com/Laurence%27s+Skull">Laurence's Skull</a> and <a href="https://bloodborne.wiki.fextralife.com/Church+Cannon">Church Cannon</a> from the altar.</li>
+            <li data-id="playthrough_24_20">Pick up <a href="https://bloodborne.wiki.fextralife.com/Laurence%27s+Skull">Laurence's Skull</a> and <a href="https://bloodborne.wiki.fextralife.com/Church+Cannon">Church Cannon</a> from the altar.</li>
         </ul>
 
         <!-- Research Hall -->
@@ -600,7 +601,7 @@
           <h2>FAQ</h2>
 
           <h3>Do I need to follow the playthrough in this exact order?</h3>
-          <p>Bloodborne is not a liner game and has multiple ways of progressing. This is generally the way I like to play through the game, so feel free to follow it if you like or mix it up. You can always jump back and forth and check things off in a different order. However, some of the NPC questlines do have specific requirements on when or how you do things, so you it is possible to miss things that way. This checklist tries to get the most of out of any NPC quests (items, gestures, etc.), but if you want to make full, informed choices, check the wiki for details on the NPCs you encounter.</p>
+          <p>Bloodborne is not a linear game and has multiple ways of progressing. This is generally the way I like to play through the game, so feel free to follow it if you like or mix it up. You can always jump back and forth and check things off in a different order. However, some of the NPC questlines do have specific requirements on when or how you do things, so you it is possible to miss things that way. This checklist tries to get the most of out of any NPC quests (items, gestures, etc.), but if you want to make full, informed choices, check the wiki for details on the NPCs you encounter.</p>
 
           <h3>Can I use this for multiple characters?</h3>
           <p>Yup, use the profile selector and buttons at the top right of the page to setup multiple characters.</p>


### PR DESCRIPTION
Solves [Issue #1](https://github.com/modo-lv/bloodborne-checklist/issues/1) and also fixes a small typo on "Information Tab"

Added the Boom Hammer about where it would be collected (in order), but set the id to the latest, so that users with data in localStorage wouldn't get the checkboxes mixed up.